### PR TITLE
Fix: Correct BottomSheet component import in AssetListRoute

### DIFF
--- a/packages/mobile/src/features/assets/components/routes/AssetListRoute.tsx
+++ b/packages/mobile/src/features/assets/components/routes/AssetListRoute.tsx
@@ -7,7 +7,7 @@ import {
   RefreshControl,
   StyleSheet,
 } from 'react-native';
-import { FlatList } from '@gymspace/sheet';
+import { BottomSheetFlatList } from '@gymspace/sheet';
 import { Text } from '@/components/ui/text';
 import { Button, ButtonText } from '@/components/ui/button';
 import { HStack } from '@/components/ui/hstack';
@@ -491,7 +491,7 @@ export const AssetListRoute: React.FC<AssetListRouteProps> = ({ route }) => {
 
   return (
     <View style={styles.container}>
-      <FlatList
+      <BottomSheetFlatList
         data={sortedAssets}
         renderItem={renderAssetItem}
         keyExtractor={keyExtractor}


### PR DESCRIPTION
## Summary
- Fixed incorrect import of `FlatList` from `@gymspace/sheet` 
- Now properly imports and uses `BottomSheetFlatList` for correct integration with bottom sheet modals

## Changes
- Updated import statement to use `BottomSheetFlatList` instead of `FlatList`
- Changed component usage from `<FlatList>` to `<BottomSheetFlatList>`

## Test plan
- [ ] Open the asset selector sheet in the mobile app
- [ ] Verify that the list of assets scrolls correctly within the bottom sheet
- [ ] Test asset selection functionality (single and multi-selection modes)
- [ ] Confirm that the sheet behaves correctly when dragging/dismissing

🤖 Generated with [Claude Code](https://claude.ai/code)